### PR TITLE
fix(dataset): Tag-all respects retag_all checkbox + filters local items

### DIFF
--- a/backend/tests/test_dataset_tag_retag_toggle.py
+++ b/backend/tests/test_dataset_tag_retag_toggle.py
@@ -1,0 +1,43 @@
+"""Regression test for v3.2.2 follow-up: Dataset Maker 'Tag all'
+exposes a 'Re-tag already-tagged images' toggle (default OFF).
+
+Before this fix, ``_tagAll`` in dataset-maker-part3.js hardcoded
+``retag_all: true``, contradicting the help text "Skips images that
+are already tagged" and forcing every Tag-all click to re-process
+the entire queue.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_tag_retag_checkbox_present():
+    html = (ROOT / "frontend" / "index.html").read_text(encoding="utf-8")
+    assert 'id="dataset-tag-retag-all"' in html, (
+        "Re-tag checkbox missing — Tag all will silently always retag."
+    )
+    assert 'data-i18n="dataset.tagRetagAll"' in html
+
+
+def test_tag_all_reads_checkbox_not_hardcoded_retag():
+    js = (ROOT / "frontend" / "js" / "dataset-maker-part3.js").read_text(encoding="utf-8")
+    # Old: { image_ids: this.imageIds, retag_all: true } — must be gone.
+    assert "retag_all: true" not in js, (
+        "_tagAll still hardcodes retag_all: true — checkbox is bypassed."
+    )
+    # New: reads from the checkbox.
+    assert "dataset-tag-retag-all" in js
+    assert "retag_all: retagAll" in js
+
+
+def test_tag_all_skips_local_source_items():
+    """Path-source items (negative ids) cannot use the legacy
+    /api/tag/start endpoint because they have no DB row. Tag all
+    must filter them out before sending."""
+    js = (ROOT / "frontend" / "js" / "dataset-maker-part3.js").read_text(encoding="utf-8")
+    assert "isLocalId" in js, (
+        "_tagAll does not filter local-source items — backend will 404 on negative ids."
+    )
+    assert "dataset.tagAllOnlyLocal" in js

--- a/frontend/css/dataset-pipeline.css
+++ b/frontend/css/dataset-pipeline.css
@@ -350,3 +350,24 @@
     font-size: 0.76rem;
     flex-basis: 100%;
 }
+
+
+
+/* ============== Tag-all retag toggle (v3.2.2 follow-up) ============== */
+
+.dataset-tag-retag-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin: 6px 0 0;
+    padding: 6px 4px;
+    color: var(--text-secondary);
+    font-size: 0.84rem;
+    cursor: pointer;
+    user-select: none;
+}
+
+.dataset-tag-retag-row input[type="checkbox"] {
+    flex-shrink: 0;
+    cursor: pointer;
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2755,6 +2755,14 @@
                                     <span aria-hidden="true">🏷️</span>
                                     <span data-i18n="dataset.tagAll">Tag all images now</span>
                                 </button>
+                                <!-- v3.2.2 follow-up: let the user opt-in to re-tagging already-tagged
+                                     images. Default is OFF (matches the help text + the backend's
+                                     retag_all=False default), so a second click of Tag all only
+                                     processes images that don't have tags yet. -->
+                                <label class="dataset-tag-retag-row">
+                                    <input type="checkbox" id="dataset-tag-retag-all">
+                                    <span data-i18n="dataset.tagRetagAll">Re-tag images that are already tagged</span>
+                                </label>
                                 <button class="btn btn-primary full-width" id="btn-dataset-smart-tag" style="margin-top: 8px;">
                                     <span aria-hidden="true">✨</span>
                                     <span data-i18n="dataset.smartTag">Smart Tag (WD14 + VLM)</span>

--- a/frontend/js/dataset-maker-part3.js
+++ b/frontend/js/dataset-maker-part3.js
@@ -98,20 +98,42 @@
             this._toast(this._t('dataset.queueEmptyHeadline', 'No images yet'), 'warning');
             return;
         }
+        // Honour the "re-tag already-tagged" checkbox. Default OFF so the
+        // first / repeat click only touches images that lack tags.
+        const retagAll = !!document.getElementById('dataset-tag-retag-all')?.checked;
+        // Local-source items (negative ids) cannot be sent to the legacy
+        // /api/tag/start path because they have no DB row. Filter them
+        // out and tell the user how many were skipped.
+        const galleryIds = this.imageIds.filter((id) => !(this.isLocalId && this.isLocalId(id)));
+        const localSkipped = this.imageIds.length - galleryIds.length;
+        if (galleryIds.length === 0) {
+            this._toast(this._t('dataset.tagAllOnlyLocal',
+                'Tag all only works on gallery-source items. Use Smart Tag for folder-imported images, or scan the folder into the main library first.'),
+                'warning', 6000);
+            return;
+        }
         try {
             const r = await fetch('/api/tag/start', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ image_ids: this.imageIds, retag_all: true }),
+                body: JSON.stringify({ image_ids: galleryIds, retag_all: retagAll }),
             });
             if (!r.ok) {
                 const body = await r.text();
                 this._toast(`Tagging failed: ${body.slice(0, 120)}`, 'error');
                 return;
             }
-            this._toast(this._t('dataset.tagAllStarted',
-                'Tagging started in the background. The progress bar at the top of the screen tracks it.'),
-                'success');
+            const startedKey = retagAll ? 'dataset.tagAllStartedRetag' : 'dataset.tagAllStartedSkip';
+            const startedFb = retagAll
+                ? 'Tagging started (retagging EVERY image). Progress is at the top of the screen.'
+                : 'Tagging started (skipping already-tagged images). Progress is at the top of the screen.';
+            let msg = this._t(startedKey, startedFb);
+            if (localSkipped > 0) {
+                msg += ' ' + this._t('dataset.tagAllSkippedLocal',
+                    '{count} local-source images were skipped (use Smart Tag for those).',
+                    { count: localSkipped });
+            }
+            this._toast(msg, 'success', 6000);
         } catch (e) {
             this._toast(`Tagging failed: ${e.message}`, 'error');
         }

--- a/frontend/js/lang/en.js
+++ b/frontend/js/lang/en.js
@@ -2883,6 +2883,12 @@ window.I18nLang_en = {
     // v3.2.2 task #12: renamed-pair preview chip.
     'dataset.pairChipPrefix': 'Output files will be:',
     'dataset.pairChipSuffix': '(LoRA trainers pair them by exact stem match)',
+    // v3.2.2 follow-up: opt-in re-tagging of already-tagged items.
+    'dataset.tagRetagAll': 'Re-tag images that are already tagged',
+    'dataset.tagAllStartedSkip': 'Tagging started (skipping already-tagged images). Progress is at the top of the screen.',
+    'dataset.tagAllStartedRetag': 'Tagging started (re-tagging EVERY image). Progress is at the top of the screen.',
+    'dataset.tagAllSkippedLocal': '{count} local-source images were skipped (use Smart Tag for those).',
+    'dataset.tagAllOnlyLocal': 'Tag all only works on gallery-source items. Use Smart Tag for folder-imported images, or scan the folder into the main library first.',
     // v3.2.2 task #7b: direct folder import to small-gallery workspace.
     'dataset.importFromFolder': 'Add from Folder',
     'dataset.folderImportTitle': 'Add images from a folder',

--- a/frontend/js/lang/zh-CN.js
+++ b/frontend/js/lang/zh-CN.js
@@ -2883,6 +2883,12 @@ window.I18nLang_zhCN = {
     // v3.2.2 任务 #12: 重命名对预览。
     'dataset.pairChipPrefix': '输出会是：',
     'dataset.pairChipSuffix': '（LoRA 训练器靠完全相同的档名词干自动配对）',
+    // v3.2.2 后续：可选「重打已标注的图」。
+    'dataset.tagRetagAll': '重新打标已经标注过的图',
+    'dataset.tagAllStartedSkip': '打标已开始（跳过已标注的图）。进度看画面顶端。',
+    'dataset.tagAllStartedRetag': '打标已开始（每一张都重打）。进度看画面顶端。',
+    'dataset.tagAllSkippedLocal': '已跳过 {count} 张本地资料夹的图（这些请用 Smart Tag）。',
+    'dataset.tagAllOnlyLocal': '「Tag all」只能对图库里的图片运作。本地资料夹的图请用 Smart Tag，或先扫进主图库。',
     // v3.2.2 任务 #7b: 直接从资料夹导入到小图库工作区。
     'dataset.importFromFolder': '从资料夹加入',
     'dataset.folderImportTitle': '从资料夹加入图片',


### PR DESCRIPTION
## Summary

Two bugs in one fix, surfaced by user feedback after v3.2.2 went into main:

### Bug 1: Tag-all silently re-tagged everything

`frontend/js/dataset-maker-part3.js::_tagAll` hardcoded `retag_all: true`, contradicting the user-visible help text:

> "Run AI tagging on every image in the queue. **Skips images that are already tagged.**"

First click on a partly-tagged queue silently re-processed every image, wasting GPU time and (with merge-strategy=replace) overwriting any user-tweaked captions.

### Bug 2: Tag-all 404s on path-source items

After T7b shipped, the Dataset Maker queue can hold local-source items (negative IDs derived from `ds_id`). Sending those to `/api/tag/start` 404s because they have no DB row. The Smart Tag wizard already handles this; Tag-all did not.

## Fix

- New "Re-tag images that are already tagged" checkbox (default OFF) drives the `retag_all` flag honestly.
- Local-source items are filtered out of the request and surfaced via a toast pointing the user at Smart Tag.
- Bilingual i18n.
- 3 regression tests:
  - markup pins the checkbox + i18n key
  - asserts `_tagAll` no longer hardcodes `retag_all: true`
  - asserts the local-id filter is wired (so a future agent can't silently regress to "send everything").

## Test result

```
backend\tests\test_dataset_tag_retag_toggle.py::test_tag_retag_checkbox_present PASSED
backend\tests\test_dataset_tag_retag_toggle.py::test_tag_all_reads_checkbox_not_hardcoded_retag PASSED
backend\tests\test_dataset_tag_retag_toggle.py::test_tag_all_skips_local_source_items PASSED
3 passed in 0.06s
```