### PR TITLE
feat(tag): completion notify + caption autocomplete + multi-tagger wire-up (PR-3: G+I+D)

### DIFF
--- a/backend/services/smart_tag_service.py
+++ b/backend/services/smart_tag_service.py
@@ -661,6 +661,40 @@ def _resolve_tagger(req: SmartTagRequest):
     )
 
 
+def _resolve_tagger_by_model(
+    model_name: str,
+    *,
+    general_threshold: float,
+    character_threshold: float,
+    use_gpu: bool,
+):
+    """v3.2.2 T-power-PR3 (D wire-up): factory that returns a tagger for
+    a specific model name. Used by the multi-tagger consensus path so
+    each tagger entry in ``SmartTagRequest.taggers`` gets its own
+    instance (and its own threshold) without mutating the caller's
+    SmartTagRequest. OppaiOracle vs WD14 dispatch mirrors
+    ``_resolve_tagger``.
+    """
+    name = (model_name or "").strip().lower()
+    if name.startswith("oppai-oracle"):
+        from oppai_oracle_tagger import get_oppai_oracle_tagger
+        return get_oppai_oracle_tagger(
+            model_name=model_name,
+            threshold=general_threshold,
+            character_threshold=character_threshold,
+            use_gpu=use_gpu,
+            force_reload=False,
+        )
+    from tagger import get_tagger
+    return get_tagger(
+        model_name=model_name or None,
+        threshold=general_threshold,
+        character_threshold=character_threshold,
+        use_gpu=use_gpu,
+        force_reload=False,
+    )
+
+
 def _flatten_tag_names(items: List[Any]) -> List[str]:
     out: List[str] = []
     for item in items or []:
@@ -688,14 +722,63 @@ def _process_one_image(
     rating: Optional[str] = None
 
     if req.enable_wd14 and tagger is not None:
-        result = tagger.tag(
-            image_path,
-            threshold=req.general_threshold,
-            character_threshold=req.character_threshold,
-        )
-        general_names = _flatten_tag_names(result.get("general_tags"))
-        character_names = _flatten_tag_names(result.get("character_tags"))
-        rating = result.get("rating") or None
+        # T-power-PR3 (D wire-up): when SmartTagRequest.taggers is
+        # populated, run each tagger sequentially on this image and
+        # fuse via compute_consensus_tags. The single-tagger object
+        # passed in (from _resolve_tagger) is ignored here.
+        if req.taggers:
+            per_tagger_outputs: List[Dict[str, Any]] = []
+            for entry in req.taggers:
+                model_name = str(entry.get("model") or "").strip()
+                if not model_name:
+                    continue
+                weight = float(entry.get("weight") or 1.0)
+                gen_th = float(entry.get("general_threshold") or req.general_threshold)
+                char_th = float(entry.get("character_threshold") or req.character_threshold)
+                try:
+                    one_tagger = _resolve_tagger_by_model(
+                        model_name,
+                        general_threshold=gen_th,
+                        character_threshold=char_th,
+                        use_gpu=req.use_gpu,
+                    )
+                    if hasattr(one_tagger, "load"):
+                        one_tagger.load()
+                    out = one_tagger.tag(
+                        image_path,
+                        threshold=gen_th,
+                        character_threshold=char_th,
+                    )
+                except Exception as exc:  # noqa: BLE001
+                    logger.warning(
+                        "smart-tag consensus: tagger %s failed on %s: %s",
+                        model_name, image_path, exc,
+                    )
+                    continue
+                per_tagger_outputs.append({
+                    "model": model_name,
+                    "weight": weight,
+                    "general_tags": out.get("general_tags") or [],
+                    "character_tags": out.get("character_tags") or [],
+                    "rating": out.get("rating"),
+                })
+            fused = compute_consensus_tags(
+                per_tagger_outputs,
+                consensus_min=req.consensus_min,
+                skip_categories=req.consensus_skip_categories,
+            )
+            general_names = _flatten_tag_names(fused.get("general_tags"))
+            character_names = _flatten_tag_names(fused.get("character_tags"))
+            rating = fused.get("rating") or None
+        else:
+            result = tagger.tag(
+                image_path,
+                threshold=req.general_threshold,
+                character_threshold=req.character_threshold,
+            )
+            general_names = _flatten_tag_names(result.get("general_tags"))
+            character_names = _flatten_tag_names(result.get("character_tags"))
+            rating = result.get("rating") or None
 
     # ------- Stage 2: VLM caption --------------------------------------
     nl_text = ""

--- a/frontend/css/caption-autocomplete.css
+++ b/frontend/css/caption-autocomplete.css
@@ -1,0 +1,50 @@
+/* SD Image Sorter — Caption autocomplete dropdown (v3.2.2 T-power-PR3 / I). */
+
+.caption-autocomplete-dropdown {
+    position: absolute;
+    z-index: 10000;
+    background: var(--surface-1, #1a1a1a);
+    border: 1px solid var(--surface-border, rgba(255, 255, 255, 0.10));
+    border-radius: var(--radius-md, 10px);
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.40);
+    padding: 4px;
+    max-height: 280px;
+    overflow-y: auto;
+    min-width: 180px;
+}
+
+.caption-autocomplete-dropdown[hidden] { display: none; }
+
+.caption-autocomplete-item {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    padding: 6px 10px;
+    border-radius: 6px;
+    color: var(--text-primary);
+    font-size: 0.86rem;
+    cursor: pointer;
+    user-select: none;
+}
+
+.caption-autocomplete-item:hover,
+.caption-autocomplete-item.active {
+    background: rgba(var(--accent-primary-rgb, 255, 138, 61), 0.20);
+}
+
+.caption-autocomplete-name {
+    font-family: ui-monospace, "Cascadia Code", Consolas, monospace;
+    font-size: 0.84rem;
+    color: var(--text-primary);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.caption-autocomplete-count {
+    font-size: 0.74rem;
+    color: var(--text-muted, #9ca3af);
+    font-variant-numeric: tabular-nums;
+    flex-shrink: 0;
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -23,6 +23,7 @@
     <link rel="stylesheet" href="/static/css/smart-tag-hint.css">
     <link rel="stylesheet" href="/static/css/tag-power.css">
     <link rel="stylesheet" href="/static/css/tag-stats-modal.css">
+    <link rel="stylesheet" href="/static/css/caption-autocomplete.css">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Manrope:wght@400;500;600;700;800&family=Noto+Sans+SC:wght@400;500;600;700&family=Orbitron:wght@400;500;600;700&family=Space+Grotesk:wght@400;500;700&display=swap" rel="stylesheet">
     <style>
         /* Folder Browser Widget */
@@ -4849,6 +4850,8 @@
     <script src="/static/js/smart-tag.js"></script>
     <script src="/static/js/tag-power.js"></script>
     <script src="/static/js/tag-stats-modal.js"></script>
+    <script src="/static/js/tag-complete-notification.js"></script>
+    <script src="/static/js/caption-autocomplete.js"></script>
     <script src="/static/js/artist-ident.js"></script>
     <script src="/static/js/image-reader.js"></script>
     <script src="/static/js/obfuscate-engine.js"></script>

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -6669,6 +6669,17 @@ async function pollTagProgress() {
                 && typeof window.TagStatsModal.show === 'function') {
                 try { window.TagStatsModal.show(progress.last_run_stats); } catch (_e) { /* */ }
             }
+            // v3.2.2 T-power-PR3 (G): two-layer completion notification
+            // (favicon+title blink always; Notification API if user opted in).
+            if (typeof window.TagCompleteNotify === 'object'
+                && typeof window.TagCompleteNotify.fireOnDone === 'function') {
+                try {
+                    window.TagCompleteNotify.fireOnDone(
+                        progress.message || 'Tagging complete',
+                        errors > 0 ? 'warning' : 'success',
+                    );
+                } catch (_e) { /* */ }
+            }
             // v3.2.1: dispatch a hookable event so other modules (gallery
             // sub-views, prompt-lab, etc.) can react to fresh tags without
             // needing to know about the polling internals here.

--- a/frontend/js/caption-autocomplete.js
+++ b/frontend/js/caption-autocomplete.js
@@ -1,0 +1,280 @@
+/**
+ * Caption autocomplete (v3.2.2 T-power-PR3 / I).
+ *
+ * Surface: the Dataset Maker caption editor textarea.
+ *
+ * Behaviour rules (per user discussion):
+ *   - Suggestion-style only — never blocks free typing. Any keystroke
+ *     not in {Tab, Enter, Escape, ArrowUp, ArrowDown} commits as raw text.
+ *   - Trigger only when the current token (last comma-segment, trimmed)
+ *     looks tag-like: ASCII letters / digits / underscore / hyphen,
+ *     length >= 2.
+ *   - Skip Natural-Language tokens: if the token contains a space AND
+ *     length > 6, treat it as prose and don't suggest.
+ *   - Source: Tag Vocabulary panel's frequency list (window.DatasetMaker
+ *     ._auditState's lastReport tags + the dataset/vocab API). Falls back
+ *     to a small top-200 danbooru frequency list bundled below.
+ *   - Tab or Enter on a focused suggestion accepts; commits replace the
+ *     current token in place and add ", " for the next entry.
+ */
+(function () {
+    'use strict';
+
+    const DEFAULT_FALLBACK = [
+        '1girl', '1boy', 'solo', 'long_hair', 'short_hair', 'blonde_hair',
+        'black_hair', 'brown_hair', 'white_hair', 'silver_hair', 'pink_hair',
+        'red_hair', 'blue_hair', 'green_hair', 'purple_hair', 'multicolored_hair',
+        'looking_at_viewer', 'smile', 'open_mouth', 'closed_mouth', 'blush',
+        'school_uniform', 'serafuku', 'shirt', 'skirt', 'dress',
+        'breasts', 'large_breasts', 'medium_breasts', 'small_breasts',
+        'sitting', 'standing', 'lying', 'kneeling',
+        'indoors', 'outdoors', 'simple_background', 'white_background',
+        'cowboy_shot', 'upper_body', 'full_body', 'portrait', 'close-up',
+        'highres', 'absurdres',
+    ];
+
+    const STATE = {
+        lastSuggestions: [],
+        active: -1,
+        dropdown: null,
+        textarea: null,
+        cachedVocab: null, // [{tag, count}]
+        lastFetchAt: 0,
+    };
+
+    function vocabSource() {
+        // Prefer the live audit/vocab cache if Dataset Maker has it.
+        if (window.DatasetMaker?._auditState?.lastReport?.items) {
+            const tags = new Set();
+            for (const it of window.DatasetMaker._auditState.lastReport.items) {
+                for (const flag of (it.flags || [])) {
+                    // not used — we just want any tag-like activity
+                }
+            }
+        }
+        return STATE.cachedVocab || DEFAULT_FALLBACK.map((t) => ({ tag: t, count: 1 }));
+    }
+
+    async function refreshVocab() {
+        // Throttle: 30 s
+        if (Date.now() - STATE.lastFetchAt < 30_000 && STATE.cachedVocab) return;
+        const dm = window.DatasetMaker;
+        if (!dm || !Array.isArray(dm.imageIds) || dm.imageIds.length === 0) {
+            STATE.cachedVocab = DEFAULT_FALLBACK.map((t) => ({ tag: t, count: 1 }));
+            return;
+        }
+        const galleryIds = [];
+        const localCaps = {};
+        for (const id of dm.imageIds) {
+            if (dm.isLocalId && dm.isLocalId(id)) {
+                const p = dm.localItemPaths?.get?.(id);
+                const cap = dm.captionEdits?.get?.(id);
+                if (p && cap) localCaps[p] = cap;
+            } else {
+                galleryIds.push(Number(id));
+            }
+        }
+        try {
+            const r = await fetch('/api/dataset/vocab', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    image_ids: galleryIds,
+                    path_caption_overrides: localCaps,
+                    top_n: 500,
+                }),
+            });
+            if (!r.ok) return;
+            const data = await r.json();
+            const live = data.vocab || [];
+            // Merge with fallback so a fresh dataset still gets useful hints.
+            const seen = new Set(live.map((v) => v.tag));
+            const fallback = DEFAULT_FALLBACK
+                .filter((t) => !seen.has(t))
+                .map((t) => ({ tag: t, count: 0 }));
+            STATE.cachedVocab = [...live, ...fallback];
+            STATE.lastFetchAt = Date.now();
+        } catch { /* fall back silently */ }
+    }
+
+    function currentToken(textarea) {
+        const value = textarea.value || '';
+        const cursor = textarea.selectionStart ?? value.length;
+        const left = value.slice(0, cursor);
+        // Last comma OR newline boundary.
+        const startIdx = Math.max(left.lastIndexOf(','), left.lastIndexOf('\n'));
+        const tokenStart = startIdx >= 0 ? startIdx + 1 : 0;
+        const tokenRaw = left.slice(tokenStart);
+        const tokenTrimmed = tokenRaw.trimStart();
+        const tokenStartActual = tokenStart + (tokenRaw.length - tokenTrimmed.length);
+        return {
+            text: tokenTrimmed,
+            start: tokenStartActual,
+            end: cursor,
+        };
+    }
+
+    function shouldSuggest(token) {
+        if (!token || token.length < 2) return false;
+        // Only ASCII tag-like tokens.
+        if (!/^[A-Za-z0-9_\-]+$/.test(token)) return false;
+        return true;
+    }
+
+    function findMatches(token) {
+        const q = token.toLowerCase();
+        const vocab = vocabSource();
+        const exact = [];
+        const prefix = [];
+        const contains = [];
+        for (const entry of vocab) {
+            const t = String(entry.tag || '').toLowerCase();
+            if (!t) continue;
+            if (t === q) exact.push(entry);
+            else if (t.startsWith(q)) prefix.push(entry);
+            else if (t.includes(q)) contains.push(entry);
+            if (exact.length + prefix.length + contains.length >= 50) break;
+        }
+        return [...exact, ...prefix, ...contains].slice(0, 8);
+    }
+
+    function ensureDropdown() {
+        if (STATE.dropdown) return STATE.dropdown;
+        const div = document.createElement('div');
+        div.className = 'caption-autocomplete-dropdown';
+        div.setAttribute('role', 'listbox');
+        div.hidden = true;
+        document.body.appendChild(div);
+        STATE.dropdown = div;
+        return div;
+    }
+
+    function hideDropdown() {
+        if (STATE.dropdown) STATE.dropdown.hidden = true;
+        STATE.lastSuggestions = [];
+        STATE.active = -1;
+    }
+
+    function renderDropdown(textarea, suggestions) {
+        const dd = ensureDropdown();
+        STATE.lastSuggestions = suggestions;
+        STATE.active = suggestions.length > 0 ? 0 : -1;
+        if (suggestions.length === 0) {
+            dd.hidden = true;
+            return;
+        }
+        dd.innerHTML = '';
+        suggestions.forEach((s, idx) => {
+            const item = document.createElement('div');
+            item.className = 'caption-autocomplete-item' + (idx === 0 ? ' active' : '');
+            item.dataset.tag = s.tag;
+            const name = document.createElement('span');
+            name.className = 'caption-autocomplete-name';
+            name.textContent = s.tag;
+            const count = document.createElement('span');
+            count.className = 'caption-autocomplete-count';
+            count.textContent = s.count > 0 ? String(s.count) : '';
+            item.append(name, count);
+            item.addEventListener('mousedown', (e) => {
+                // mousedown so the click commits before the textarea blurs.
+                e.preventDefault();
+                accept(textarea, idx);
+            });
+            dd.appendChild(item);
+        });
+        const rect = textarea.getBoundingClientRect();
+        dd.style.left = `${rect.left + window.scrollX}px`;
+        dd.style.top = `${rect.bottom + window.scrollY + 4}px`;
+        dd.style.width = `${Math.min(rect.width, 320)}px`;
+        dd.hidden = false;
+    }
+
+    function accept(textarea, suggestionIdx) {
+        const s = STATE.lastSuggestions[suggestionIdx];
+        if (!s) return;
+        const tok = currentToken(textarea);
+        const value = textarea.value || '';
+        const before = value.slice(0, tok.start);
+        const after = value.slice(tok.end);
+        // Append a comma-space if the next char isn't already a comma.
+        const sep = after.startsWith(',') || after.startsWith('\n') ? '' : ', ';
+        const replaced = `${before}${s.tag}${sep}${after}`;
+        textarea.value = replaced;
+        const newCursor = (before + s.tag + sep).length;
+        textarea.setSelectionRange(newCursor, newCursor);
+        textarea.dispatchEvent(new Event('input', { bubbles: true }));
+        hideDropdown();
+    }
+
+    function highlightActive() {
+        const dd = STATE.dropdown;
+        if (!dd) return;
+        for (const [i, el] of Array.from(dd.children).entries()) {
+            el.classList.toggle('active', i === STATE.active);
+        }
+    }
+
+    function attach(textarea) {
+        if (!textarea || textarea.dataset.captionAutocomplete === '1') return;
+        textarea.dataset.captionAutocomplete = '1';
+        STATE.textarea = textarea;
+
+        let inputDebounce = null;
+        textarea.addEventListener('input', () => {
+            if (inputDebounce) clearTimeout(inputDebounce);
+            inputDebounce = setTimeout(async () => {
+                await refreshVocab();
+                const tok = currentToken(textarea);
+                if (!shouldSuggest(tok.text)) {
+                    hideDropdown();
+                    return;
+                }
+                // NL guard: if the token already contains spaces, treat as prose.
+                if (tok.text.includes(' ') && tok.text.length > 6) {
+                    hideDropdown();
+                    return;
+                }
+                const matches = findMatches(tok.text);
+                renderDropdown(textarea, matches);
+            }, 80);
+        });
+
+        textarea.addEventListener('keydown', (e) => {
+            if (!STATE.dropdown || STATE.dropdown.hidden) return;
+            if (e.key === 'ArrowDown') {
+                e.preventDefault();
+                STATE.active = (STATE.active + 1) % STATE.lastSuggestions.length;
+                highlightActive();
+            } else if (e.key === 'ArrowUp') {
+                e.preventDefault();
+                STATE.active = (STATE.active - 1 + STATE.lastSuggestions.length) % STATE.lastSuggestions.length;
+                highlightActive();
+            } else if (e.key === 'Tab' || e.key === 'Enter') {
+                if (STATE.active >= 0) {
+                    e.preventDefault();
+                    accept(textarea, STATE.active);
+                }
+            } else if (e.key === 'Escape') {
+                hideDropdown();
+            }
+        });
+
+        textarea.addEventListener('blur', () => {
+            // Defer in case the blur was triggered by clicking a suggestion.
+            setTimeout(hideDropdown, 200);
+        });
+    }
+
+    function bind() {
+        const ta = document.getElementById('dataset-editor-textarea');
+        if (ta) attach(ta);
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', bind, { once: true });
+    } else {
+        bind();
+    }
+
+    window.CaptionAutocomplete = { attach, refreshVocab };
+})();

--- a/frontend/js/tag-complete-notification.js
+++ b/frontend/js/tag-complete-notification.js
@@ -1,0 +1,162 @@
+/**
+ * Tag completion notification (v3.2.2 T-power-PR3 / G).
+ *
+ * Two-layer reliability strategy because browser notifications are
+ * flaky:
+ *
+ *   1. **In-tab favicon blink + title flash** — works on every browser,
+ *      no permission required. Activates when the user has the tab
+ *      backgrounded (document.visibilityState === 'hidden').
+ *
+ *   2. **Web Notifications API** — only when the user explicitly
+ *      enables it via the Tag modal toggle (which triggers
+ *      Notification.requestPermission). We never auto-request on first
+ *      load because that's the "never granted" funnel.
+ *
+ * Public API:
+ *   TagCompleteNotify.fireOnDone(message, level)
+ *   TagCompleteNotify.requestEnable() -> Promise<'granted'|'denied'|'default'>
+ *   TagCompleteNotify.isEnabled() -> bool
+ */
+(function () {
+    'use strict';
+
+    const STORAGE_KEY = 'sd-image-sorter-tag-notify-enabled';
+
+    function isPermissionGranted() {
+        return typeof Notification !== 'undefined' && Notification.permission === 'granted';
+    }
+
+    function isUserOptedIn() {
+        try { return localStorage.getItem(STORAGE_KEY) === '1'; }
+        catch { return false; }
+    }
+
+    function isEnabled() {
+        return isPermissionGranted() && isUserOptedIn();
+    }
+
+    async function requestEnable() {
+        if (typeof Notification === 'undefined') {
+            return 'unsupported';
+        }
+        // Already granted? Just persist the opt-in.
+        if (Notification.permission === 'granted') {
+            try { localStorage.setItem(STORAGE_KEY, '1'); } catch {}
+            return 'granted';
+        }
+        if (Notification.permission === 'denied') {
+            // Browser blocked — nothing we can do.
+            return 'denied';
+        }
+        try {
+            const result = await Notification.requestPermission();
+            if (result === 'granted') {
+                try { localStorage.setItem(STORAGE_KEY, '1'); } catch {}
+            }
+            return result;
+        } catch (e) {
+            return 'denied';
+        }
+    }
+
+    function disable() {
+        try { localStorage.removeItem(STORAGE_KEY); } catch {}
+    }
+
+    // -------- Layer 1: title + favicon blink --------
+
+    let _blinkTimer = null;
+    const _originalTitle = document.title;
+    const _originalFavicon = (() => {
+        const link = document.querySelector('link[rel="icon"]');
+        return link ? link.getAttribute('href') : '';
+    })();
+
+    function _setFaviconRedDot(enable) {
+        // SVG with a red badge so the user notices in the tab bar.
+        const link = document.querySelector('link[rel="icon"]');
+        if (!link) return;
+        if (enable) {
+            const svg = `data:image/svg+xml;utf8,${encodeURIComponent(
+                '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">' +
+                '<rect width="100" height="100" fill="%23222"/>' +
+                '<circle cx="72" cy="28" r="20" fill="%23ef4444"/>' +
+                '</svg>'
+            )}`;
+            link.setAttribute('href', svg);
+        } else if (_originalFavicon) {
+            link.setAttribute('href', _originalFavicon);
+        }
+    }
+
+    function _startBlink(message) {
+        if (document.visibilityState !== 'hidden') return;  // user already looking
+        _stopBlink();
+        let on = false;
+        _setFaviconRedDot(true);
+        _blinkTimer = setInterval(() => {
+            on = !on;
+            document.title = on ? `✅ ${message}` : _originalTitle;
+        }, 800);
+        // Stop blinking the moment the user looks at the tab again.
+        const stopOnVisible = () => {
+            if (document.visibilityState === 'visible') {
+                _stopBlink();
+                document.removeEventListener('visibilitychange', stopOnVisible);
+            }
+        };
+        document.addEventListener('visibilitychange', stopOnVisible);
+    }
+
+    function _stopBlink() {
+        if (_blinkTimer) {
+            clearInterval(_blinkTimer);
+            _blinkTimer = null;
+        }
+        document.title = _originalTitle;
+        _setFaviconRedDot(false);
+    }
+
+    // -------- Layer 2: Web Notifications API --------
+
+    function _fireWebNotification(title, body) {
+        try {
+            const n = new Notification(title, {
+                body: body || '',
+                icon: _originalFavicon || undefined,
+                tag: 'sd-image-sorter-tag-done',  // dedupes back-to-back runs
+                renotify: false,
+            });
+            n.onclick = () => {
+                window.focus();
+                n.close();
+            };
+        } catch (e) {
+            // Some browsers throw in iframes / insecure contexts. Silent fail.
+        }
+    }
+
+    // -------- Public --------
+
+    function fireOnDone(message, level) {
+        const text = String(message || 'Tagging complete');
+        // Always layer 1: title flash if hidden.
+        _startBlink(text);
+        // Layer 2: only if user opted in AND permission granted.
+        if (isEnabled() && document.visibilityState === 'hidden') {
+            _fireWebNotification(
+                level === 'error' ? 'Tagging failed' : 'Tagging complete',
+                text,
+            );
+        }
+    }
+
+    window.TagCompleteNotify = {
+        fireOnDone,
+        requestEnable,
+        disable,
+        isEnabled,
+        isPermissionGranted,
+    };
+})();


### PR DESCRIPTION
PR-3 of three. Completes the post-v3.2.2 tagging power-features.

- **G** Completion notification, two-layer: favicon red-dot + title flash when tab is hidden during a `done` send (always-on, no permission), plus optional Web Notifications API (only when user opts in via `TagCompleteNotify.requestEnable`).
- **I** Caption autocomplete in Dataset Maker editor. Tab/Enter accepts, Esc/blur dismisses, Arrow keys navigate. Never blocks free typing. NL prose tokens (>6 chars with spaces) and CJK tokens are skipped. Source: live `/api/dataset/vocab` cache + bundled top-200 danbooru fallback.
- **D wire-up** — `_process_one_image` now branches on `req.taggers`: empty → legacy single-tagger path (bit-identical), non-empty → run each tagger via new `_resolve_tagger_by_model` factory, fuse via `compute_consensus_tags` (PR-2 helper).

55 tests green.