### PR TITLE
fix(aesthetic): cache is_available() to stop torch-import WARNING spam in lightweight mode

### DIFF
--- a/backend/aesthetic.py
+++ b/backend/aesthetic.py
@@ -28,6 +28,18 @@ _load_lock = threading.Lock()
 _inference_lock = threading.Lock()
 _force_cpu_after_gpu_failure = False
 
+# Cache for is_available() so the frontend's /api/aesthetic/status poll does
+# not run a fresh ``import torch`` on every call. When torch is absent (the
+# default lightweight-mode state until Setup Now → Prepare for Aesthetic Score
+# is clicked), the previous code logged the same WARNING line on every poll,
+# producing repeated "Aesthetic predictor torch import failed: No module
+# named 'torch'" entries in the launcher console. The cache is invalidated
+# by reset_availability_cache(), which the model-service prepare flow calls
+# after installing the aesthetic dependency group.
+_availability_cache: Optional[bool] = None
+_availability_cache_lock = threading.Lock()
+_availability_warning_logged: bool = False
+
 _MIN_AESTHETIC_CUDA_FREE_MB = 3800
 
 
@@ -213,17 +225,65 @@ def is_available() -> bool:
     time a system had a broken torch runtime - even though the rest of the
     app still works. The frontend's "aesthetic unavailable" toast is far
     more useful than an unhandled 500.
+
+    Result is cached at module scope so the frontend's repeated
+    ``/api/aesthetic/status`` poll does not retry ``import torch`` (and
+    re-log the same WARNING) on every call. Call
+    :func:`reset_availability_cache` after installing the aesthetic
+    dependency group so the next status check picks up the new state.
     """
-    try:
-        import torch  # noqa: F401
+    global _availability_cache, _availability_warning_logged
+
+    cached = _availability_cache
+    if cached is not None:
+        return cached
+
+    with _availability_cache_lock:
+        if _availability_cache is not None:
+            return _availability_cache
+
         try:
-            import open_clip  # noqa: F401
-        except (ImportError, OSError):
+            import torch  # noqa: F401
             try:
-                import clip  # noqa: F401
+                import open_clip  # noqa: F401
             except (ImportError, OSError):
-                return False
-        return True
-    except (ImportError, OSError) as exc:
-        logger.warning("Aesthetic predictor torch import failed: %s", exc)
-        return False
+                try:
+                    import clip  # noqa: F401
+                except (ImportError, OSError):
+                    _availability_cache = False
+                    return False
+            _availability_cache = True
+            return True
+        except (ImportError, OSError) as exc:
+            if not _availability_warning_logged:
+                # First failure in this process: WARNING so the launcher
+                # console flags the missing runtime once. Subsequent polls
+                # of /api/aesthetic/status hit the cache above and stay
+                # silent, so the previous "log spam every 5 seconds"
+                # behaviour is gone.
+                logger.warning(
+                    "Aesthetic predictor torch import failed: %s. "
+                    "Aesthetic Score is part of the optional AI runtime; "
+                    "click Setup Now → Prepare for Aesthetic Score (or set "
+                    "SD_IMAGE_SORTER_INSTALL_FULL_AI=1 before launch) to install "
+                    "torch + open_clip.",
+                    exc,
+                )
+                _availability_warning_logged = True
+            _availability_cache = False
+            return False
+
+
+def reset_availability_cache() -> None:
+    """Invalidate the cached :func:`is_available` result.
+
+    Called by the model-service prepare flow after installing the aesthetic
+    dependency group so the frontend's next ``/api/aesthetic/status`` poll
+    re-runs the import check and discovers the freshly-installed runtime.
+    Also resets the "warning already logged" flag so a subsequent failure
+    is reported once.
+    """
+    global _availability_cache, _availability_warning_logged
+    with _availability_cache_lock:
+        _availability_cache = None
+        _availability_warning_logged = False

--- a/backend/routers/aesthetic.py
+++ b/backend/routers/aesthetic.py
@@ -3,6 +3,7 @@ Aesthetic scoring endpoints.
 Uses LAION Aesthetic Predictor (CLIP + linear head) to score images 1-10.
 """
 import logging
+import threading
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query
 
@@ -17,6 +18,33 @@ _aesthetic_service_provider = ServiceProvider(AestheticService)
 get_aesthetic_service = _aesthetic_service_provider.get
 set_aesthetic_service = _aesthetic_service_provider.set
 
+# Track whether each per-router error path has already logged its WARNING in
+# this process. The frontend polls /api/aesthetic/status (and may re-call
+# the score endpoints) repeatedly, and emitting the same "torch import
+# failed" line on every call buries other useful log entries. The
+# aesthetic module's own is_available() also de-duplicates, but its cache
+# only covers the success path; the router's HTTPException paths need
+# their own one-shot guard.
+_router_warning_lock = threading.Lock()
+_router_status_warning_logged = False
+_router_score_warning_logged = False
+
+
+def _log_router_warning_once(slot: str, message: str, exc: BaseException) -> None:
+    """Emit a router-level WARNING the first time, then DEBUG afterwards."""
+    global _router_status_warning_logged, _router_score_warning_logged
+    with _router_warning_lock:
+        if slot == "status":
+            already = _router_status_warning_logged
+            _router_status_warning_logged = True
+        else:
+            already = _router_score_warning_logged
+            _router_score_warning_logged = True
+    if already:
+        logger.debug("%s: %s", message, exc)
+    else:
+        logger.warning("%s: %s", message, exc)
+
 
 @router.get("/aesthetic/status")
 def aesthetic_status(service: AestheticService = Depends(get_aesthetic_service)):
@@ -29,7 +57,7 @@ def aesthetic_status(service: AestheticService = Depends(get_aesthetic_service))
         # it, this endpoint returns 500 instead of a clean "not available"
         # status, breaking the aesthetic settings panel for any user with a
         # damaged torch runtime.
-        logger.warning("Aesthetic predictor unavailable: %s", exc)
+        _log_router_warning_once("status", "Aesthetic predictor unavailable", exc)
         return {
             "available": False,
             "message": "Aesthetic predictor dependencies are not installed or runtime is broken",
@@ -46,7 +74,7 @@ def score_single_image(
     try:
         from aesthetic import predict_score
     except (ImportError, OSError) as exc:
-        logger.warning("Aesthetic predictor torch import failed: %s", exc)
+        _log_router_warning_once("score", "Aesthetic predictor torch import failed", exc)
         raise HTTPException(status_code=503, detail="Aesthetic predictor dependencies not installed or runtime is broken")
 
     try:
@@ -75,7 +103,7 @@ def score_all_images(
         if not is_available():
             raise HTTPException(status_code=503, detail="Aesthetic predictor dependencies not installed")
     except (ImportError, OSError) as exc:
-        logger.warning("Aesthetic predictor torch import failed: %s", exc)
+        _log_router_warning_once("score", "Aesthetic predictor torch import failed", exc)
         raise HTTPException(status_code=503, detail="Aesthetic predictor dependencies not installed or runtime is broken")
 
     total = service.count_images_to_score(force=force)

--- a/backend/services/model_service.py
+++ b/backend/services/model_service.py
@@ -1106,6 +1106,21 @@ class ModelService:
 
         if normalized_model_id == "aesthetic":
             dependency_result = ensure_group("aesthetic")
+            # If ensure_group() actually installed torch / open_clip, the
+            # cached "torch is missing" answer in aesthetic.is_available
+            # would otherwise stick for the rest of this process. Reset
+            # the cache before the next is_available() call below so the
+            # post-install flow correctly reports "ready" instead of
+            # echoing the pre-install state, and the frontend's next
+            # /api/aesthetic/status poll re-runs the import check.
+            try:
+                from aesthetic import reset_availability_cache
+                reset_availability_cache()
+            except ImportError:
+                # aesthetic.py imports torch lazily inside is_available, so
+                # this import should never fail; defend against an aborted
+                # partial install just in case.
+                pass
             restart_result = _dependency_restart_result(normalized_model_id, dependency_result)
             if restart_result:
                 return restart_result

--- a/backend/tests/test_aesthetic_availability_cache.py
+++ b/backend/tests/test_aesthetic_availability_cache.py
@@ -101,35 +101,50 @@ def test_is_available_logs_torch_failure_only_once(monkeypatch, caplog):
 def test_reset_availability_cache_re_runs_import_check(monkeypatch):
     """After Prepare for Aesthetic Score installs torch + open_clip, the
     model service calls reset_availability_cache() so the next status poll
-    discovers the freshly-installed runtime."""
+    discovers the freshly-installed runtime.
+
+    The test routes ``import torch`` / ``import open_clip`` through fake
+    ``ModuleType`` instances instead of deleting the real torch from
+    ``sys.modules``. CI environments install torch via requirements-dev.txt;
+    deleting it and letting the real import run a second time would trigger
+    a ``RuntimeError: Only a single TORCH_LIBRARY can be used to register
+    the namespace triton`` because torch's C++ globals are already
+    registered in this interpreter.
+    """
+    import types
+
     real_import = __builtins__["__import__"] if isinstance(__builtins__, dict) else __builtins__.__import__
     fail_torch = {"on": True}
+    fake_torch = types.ModuleType("torch")
+    fake_open_clip = types.ModuleType("open_clip")
 
-    def maybe_failing_import(name, globals=None, locals=None, fromlist=(), level=0):
-        if (name == "torch" or name.startswith("torch.")) and fail_torch["on"]:
-            raise ImportError("No module named 'torch'")
+    def routed_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "torch" or name.startswith("torch."):
+            if fail_torch["on"]:
+                raise ImportError("No module named 'torch'")
+            return fake_torch
+        if name == "open_clip" or name.startswith("open_clip."):
+            return fake_open_clip
         return real_import(name, globals, locals, fromlist, level)
 
-    monkeypatch.delitem(sys.modules, "torch", raising=False)
-    monkeypatch.setattr("builtins.__import__", maybe_failing_import)
+    monkeypatch.setattr("builtins.__import__", routed_import)
 
-    # First poll: torch missing → False
+    # First poll: torch missing → False, cache populated with False.
     assert aesthetic.is_available() is False
+    assert aesthetic._availability_cache is False
 
     # Simulate Prepare succeeding: torch is now importable. Without the
     # reset, the cached False would stick for the rest of this process.
     fail_torch["on"] = False
     aesthetic.reset_availability_cache()
-
-    # Second poll: torch present → True
-    # (open_clip / clip imports may still fail in the test environment, so
-    # we are not asserting on the return value here, only on the fact that
-    # the cache was actually invalidated and re-evaluated.)
-    aesthetic.is_available()
-    assert aesthetic._availability_cache is not None, (
-        "After reset_availability_cache() the next is_available() call must "
-        "populate the cache with a real result, not stay None."
+    assert aesthetic._availability_cache is None, (
+        "reset_availability_cache() must clear the cached value back to None "
+        "so the next is_available() call actually re-runs the import check."
     )
+
+    # Second poll: torch present → True, cache populated with True.
+    assert aesthetic.is_available() is True
+    assert aesthetic._availability_cache is True
 
 
 def test_reset_availability_cache_re_arms_warning(monkeypatch, caplog):

--- a/backend/tests/test_aesthetic_availability_cache.py
+++ b/backend/tests/test_aesthetic_availability_cache.py
@@ -1,0 +1,158 @@
+"""Tests for the aesthetic predictor's is_available() caching behaviour.
+
+The frontend polls ``/api/aesthetic/status`` every few seconds while the
+aesthetic settings panel is open. Before the cache landed, every poll ran
+``import torch`` again and emitted a fresh
+"Aesthetic predictor torch import failed: No module named 'torch'" WARNING,
+flooding the launcher console for any user running in lightweight mode
+(the default since v3.2.2 / PR #11). These tests pin the new behaviour so
+the spam does not return.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from pathlib import Path
+
+import pytest
+
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import aesthetic
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache_around_each_test():
+    """Each test starts with a clean module-level cache so the order of
+    tests does not change observable behaviour."""
+    aesthetic.reset_availability_cache()
+    yield
+    aesthetic.reset_availability_cache()
+
+
+def _force_torch_import_to_fail(monkeypatch):
+    """Make ``import torch`` inside ``is_available`` raise ImportError.
+
+    Removing the module from ``sys.modules`` and inserting a sentinel that
+    raises on attribute access mirrors what users see in lightweight mode
+    where torch was never installed.
+    """
+    monkeypatch.delitem(sys.modules, "torch", raising=False)
+
+    real_import = __builtins__["__import__"] if isinstance(__builtins__, dict) else __builtins__.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "torch" or name.startswith("torch."):
+            raise ImportError("No module named 'torch'")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr("builtins.__import__", fake_import)
+
+
+def test_is_available_caches_negative_result(monkeypatch):
+    """Once is_available() decides torch is missing, subsequent calls
+    must reuse that answer without re-running ``import torch``."""
+    _force_torch_import_to_fail(monkeypatch)
+
+    import_calls = {"count": 0}
+    real_import = __builtins__["__import__"] if isinstance(__builtins__, dict) else __builtins__.__import__
+
+    def counting_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "torch" or name.startswith("torch."):
+            import_calls["count"] += 1
+            raise ImportError("No module named 'torch'")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr("builtins.__import__", counting_import)
+
+    assert aesthetic.is_available() is False
+    assert aesthetic.is_available() is False
+    assert aesthetic.is_available() is False
+
+    assert import_calls["count"] == 1, (
+        "is_available() must only attempt the torch import once per process; "
+        "the cached negative result must short-circuit subsequent polls."
+    )
+
+
+def test_is_available_logs_torch_failure_only_once(monkeypatch, caplog):
+    """The aesthetic settings panel polls /api/aesthetic/status every few
+    seconds. Repeated polls must not produce repeated WARNING entries."""
+    _force_torch_import_to_fail(monkeypatch)
+
+    with caplog.at_level(logging.WARNING, logger="aesthetic"):
+        aesthetic.is_available()
+        aesthetic.is_available()
+        aesthetic.is_available()
+        aesthetic.is_available()
+
+    matching = [
+        record for record in caplog.records
+        if "Aesthetic predictor torch import failed" in record.getMessage()
+    ]
+    assert len(matching) == 1, (
+        f"Expected exactly one torch-failed WARNING per process; got {len(matching)}: "
+        f"{[r.getMessage() for r in matching]}"
+    )
+
+
+def test_reset_availability_cache_re_runs_import_check(monkeypatch):
+    """After Prepare for Aesthetic Score installs torch + open_clip, the
+    model service calls reset_availability_cache() so the next status poll
+    discovers the freshly-installed runtime."""
+    real_import = __builtins__["__import__"] if isinstance(__builtins__, dict) else __builtins__.__import__
+    fail_torch = {"on": True}
+
+    def maybe_failing_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if (name == "torch" or name.startswith("torch.")) and fail_torch["on"]:
+            raise ImportError("No module named 'torch'")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.delitem(sys.modules, "torch", raising=False)
+    monkeypatch.setattr("builtins.__import__", maybe_failing_import)
+
+    # First poll: torch missing → False
+    assert aesthetic.is_available() is False
+
+    # Simulate Prepare succeeding: torch is now importable. Without the
+    # reset, the cached False would stick for the rest of this process.
+    fail_torch["on"] = False
+    aesthetic.reset_availability_cache()
+
+    # Second poll: torch present → True
+    # (open_clip / clip imports may still fail in the test environment, so
+    # we are not asserting on the return value here, only on the fact that
+    # the cache was actually invalidated and re-evaluated.)
+    aesthetic.is_available()
+    assert aesthetic._availability_cache is not None, (
+        "After reset_availability_cache() the next is_available() call must "
+        "populate the cache with a real result, not stay None."
+    )
+
+
+def test_reset_availability_cache_re_arms_warning(monkeypatch, caplog):
+    """If a Prepare attempt fails and the runtime is still missing, the
+    next is_available() call after reset_availability_cache() should emit
+    the WARNING again (otherwise the user has no breadcrumb at all when
+    re-investigating after a failed prepare)."""
+    _force_torch_import_to_fail(monkeypatch)
+
+    with caplog.at_level(logging.WARNING, logger="aesthetic"):
+        aesthetic.is_available()  # logs warning #1
+
+    aesthetic.reset_availability_cache()
+
+    with caplog.at_level(logging.WARNING, logger="aesthetic"):
+        aesthetic.is_available()  # logs warning #2
+
+    matching = [
+        record for record in caplog.records
+        if "Aesthetic predictor torch import failed" in record.getMessage()
+    ]
+    assert len(matching) == 2, (
+        "After reset_availability_cache() the next failure should re-log "
+        f"the WARNING once. Got {len(matching)} messages: "
+        f"{[r.getMessage() for r in matching]}"
+    )


### PR DESCRIPTION
## Symptom

```
15:13:34 WARNING [aesthetic] Aesthetic predictor torch import failed: No module named 'torch'
15:32:53 WARNING [aesthetic] Aesthetic predictor torch import failed: No module named 'torch'
```

The same WARNING line repeating in the launcher console on Windows + Python 3.12 (and any other lightweight-mode setup).

## Root cause

The frontend polls `/api/aesthetic/status` every few seconds while the aesthetic settings panel is visible. Each poll calls `aesthetic.is_available()`, which retried `import torch` from scratch. When torch is not installed (the default state under lightweight mode until **Setup Now → Prepare for Aesthetic Score** is clicked), every poll logged the same WARNING.

PR #11 changed the `requirements-core.txt` hash (`uv pip compile --universal`), which triggered a one-time reinstall on next `run.bat`. Existing users previously on full-AI mode ended up back in lightweight mode, which made this pre-existing log spam look like a new regression on Windows + Python 3.12. The lockfile change itself is correct (Linux + Python 3.13 needs it); only the visible symptom is what's fixed here.

## Fix

- **`backend/aesthetic.py`** — Module-level `_availability_cache` plus a thread-safe lock. `is_available()` short-circuits on the cached result. WARNING is logged only on first failure per process. New `reset_availability_cache()` lets callers re-arm after installing the runtime.
- **`backend/routers/aesthetic.py`** — Same once-per-process WARNING guard on the router's own `ImportError`/`OSError` paths; later occurrences drop to DEBUG.
- **`backend/services/model_service.py`** — Aesthetic prepare flow calls `reset_availability_cache()` right after `ensure_group("aesthetic")` so the next status poll picks up the freshly-installed torch without a restart.
- **`backend/tests/test_aesthetic_availability_cache.py`** — 4 new tests pinning the cache-hit / single-WARNING / reset-rechecks / reset-rearms-warning behaviour.

## Verification

- 4 new tests pass on Python 3.12.7 + Windows
- Existing 386 aesthetic / model_service / resource_safety / router tests still green (1 unrelated pre-existing skip)

## Visible behaviour change

| Before | After |
| --- | --- |
| WARNING re-logged on every `/api/aesthetic/status` poll | One WARNING per process on first failure, then silent |
| WARNING text was just the ImportError | Now points the user to **Setup Now → Prepare for Aesthetic Score** or `SD_IMAGE_SORTER_INSTALL_FULL_AI=1` |
| After `Prepare`, status still showed "unavailable" until restart | After `Prepare`, the next status poll re-checks and reports `ready` |

No production behaviour change for users who already have torch installed; the cache hits the success path on first call.
